### PR TITLE
:pencil: Remove namespace modifier from twig templates

### DIFF
--- a/src/Resources/doc/index.rst
+++ b/src/Resources/doc/index.rst
@@ -144,7 +144,7 @@ You just need to create all "Component" class you want.
          */
         public function default(): string
         {
-            return $this->render('@components/atoms/button/button.html.twig', [
+            return $this->render('components/atoms/button/button.html.twig', [
                 'props' => [
                     'label' => 'My awesome button',
                 ]
@@ -163,7 +163,7 @@ You just need to create all "Component" class you want.
             $buttons = [];
 
             foreach ($colors as $color) {
-                $buttons[] = $this->render('@components/atoms/button/button.html.twig', [
+                $buttons[] = $this->render('components/atoms/button/button.html.twig', [
                     'props' => [
                         'label' => ucfirst($color),
                         'class_modifiers' => [$color]


### PR DESCRIPTION
Hi :wave: 

thank you for your cool project. I just installed it and followed the instructions, but got an exception.

> `There are no registered paths for namespace "components".`

I checked your demo (https://github.com/qmachard/atomic-design-demo-symfony) and saw that it does not use twig namespaces, so i suggest they should be removed from the documentation as well.