### PR TITLE
Allow sensio/framework-extra-bundle 6.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": "^7.3|^8.0",
         "symfony/framework-bundle": "^4.4|^5.0",
-        "sensio/framework-extra-bundle": "^4.4|^5.1",
+        "sensio/framework-extra-bundle": "^4.4|^5.1|^6.0",
         "symfony/twig-bundle": "^4.4|^5.2",
         "symfony/webpack-encore-bundle": "^1.8"
     },


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.x
| Bug fix?        | no
| New feature?    | yes
| Related tickets | fixes #37
| License         | MIT

I've been testing the bundle with `sensio/framework-extra-bundle:6.x`, and I've seen no compatibility issue.