### PR TITLE
Allow configuration of Assets package name

### DIFF
--- a/src/Controller/StoryController.php
+++ b/src/Controller/StoryController.php
@@ -21,6 +21,12 @@ class StoryController extends AbstractController
     /** @var string */
     private $jsEntryName;
 
+    /** @var string */
+    private $cssPackageName;
+
+    /** @var string */
+    private $jsPackageName;
+
     /** @var ComponentProviderInterface */
     private $componentProvider;
 
@@ -30,6 +36,8 @@ class StoryController extends AbstractController
     public function __construct(
         ?string $cssEntryName,
         ?string $jsEntryName,
+        ?string $cssPackageName,
+        ?string $jsPackageName,
         ComponentProviderInterface $componentProvider,
         ComponentMenuBuilderInterface $menuBuilder,
         ?Profiler $profiler
@@ -41,6 +49,8 @@ class StoryController extends AbstractController
         $this->componentProvider = $componentProvider;
         $this->cssEntryName = $cssEntryName;
         $this->jsEntryName = $jsEntryName;
+        $this->cssPackageName = $cssPackageName;
+        $this->jsPackageName = $jsPackageName;
         $this->menuBuilder = $menuBuilder;
     }
 
@@ -85,6 +95,8 @@ class StoryController extends AbstractController
             'render' => $render,
             'css_entry_name' => $this->cssEntryName,
             'js_entry_name' => $this->jsEntryName,
+            'css_package_name' => $this->cssPackageName,
+            'js_package_name' => $this->jsPackageName,
         ]);
     }
 }

--- a/src/DependencyInjection/AtomicDesignExtension.php
+++ b/src/DependencyInjection/AtomicDesignExtension.php
@@ -30,5 +30,7 @@ class AtomicDesignExtension extends Extension
 
         $definition->setArgument(0, $config['css_entry_name']);
         $definition->setArgument(1, $config['js_entry_name']);
+        $definition->setArgument(2, $config['css_package_name']);
+        $definition->setArgument(3, $config['js_package_name']);
     }
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -24,6 +24,14 @@ class Configuration implements ConfigurationInterface
                 ->defaultValue('app')
                 ->info('Encore JS entry name.')
             ->end()
+            ->scalarNode('css_package_name')
+                ->defaultNull()
+                ->info('Encore CSS package name.')
+            ->end()
+            ->scalarNode('js_package_name')
+            ->defaultNull()
+                ->info('Encore JS package name.')
+            ->end()
         ;
 
         return $treeBuilder;

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -24,6 +24,8 @@
         <service id="atomic_design.controller.story" class="QuentinMachard\Bundle\AtomicDesignBundle\Controller\StoryController" public="true">
             <argument type="string" key="$cssEntryName" on-invalid="null" />
             <argument type="string" key="$jsEntryName" on-invalid="null" />
+            <argument type="string" key="$cssPackageName" on-invalid="null" />
+            <argument type="string" key="$jsPackageName" on-invalid="null" />
             <argument type="service" key="$profiler" id="profiler" on-invalid="null" />
         </service>
 

--- a/src/Resources/views/embed.html.twig
+++ b/src/Resources/views/embed.html.twig
@@ -6,14 +6,26 @@
     <title>Document</title>
 
     {% block stylesheets %}
-        {% if css_entry_name is not empty %}{{ encore_entry_link_tags(css_entry_name) }}{% endif %}
+        {% if css_entry_name is not empty %}
+            {% if css_package_name is not empty %}
+                {{ encore_entry_link_tags(css_entry_name, null, css_package_name) }}
+            {% else %}
+                {{ encore_entry_link_tags(css_entry_name) }}
+            {% endif %}
+        {% endif %}
     {% endblock %}
 </head>
 <body>
     {{ render|raw }}
 
     {% block javascripts %}
-        {% if js_entry_name is not empty %}{{ encore_entry_script_tags(js_entry_name) }}{% endif %}
+        {% if js_entry_name is not empty %}
+            {% if js_package_name is not empty %}
+                {{ encore_entry_link_tags(js_entry_name, null, js_package_name) }}
+            {% else %}
+                {{ encore_entry_link_tags(js_entry_name) }}
+            {% endif %}
+        {% endif %}
     {% endblock %}
 </body>
 </html>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.x
| Bug fix?        | no
| New feature?    | yes
| Related tickets | fnone
| License         | MIT

When you have an application with multiple webpack encore configuration, you are required to specify the 3rd argument of `encore_entry_link_tags` and `encore_entry_link_tags` Twig methods

https://symfony.com/doc/current/frontend/encore/advanced-config.html#defining-multiple-webpack-configurations

This PR introduces 2 configuration vars : `css_package_name` & `js_package_name` that are covering that need.